### PR TITLE
加速度センサーの感度を大幅に改善

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -170,6 +170,40 @@ p {
     }
 }
 
+/* デバッグパネル */
+#debug-info {
+    position: absolute;
+    top: 100px;
+    left: 10px;
+    background-color: rgba(0, 0, 0, 0.8);
+    padding: 0.8rem;
+    border-radius: 5px;
+    font-size: 0.8rem;
+    font-family: monospace;
+    color: #0f0;
+    border: 1px solid #0f0;
+    max-width: 200px;
+    line-height: 1.4;
+}
+
+/* 操作説明 */
+.controls-info {
+    position: absolute;
+    bottom: 100px;
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: rgba(102, 126, 234, 0.9);
+    padding: 0.8rem 1.5rem;
+    border-radius: 20px;
+    text-align: center;
+}
+
+.controls-info p {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: bold;
+}
+
 /* モバイル対応 */
 @media (max-width: 768px) {
     h1 {
@@ -197,5 +231,19 @@ p {
 
     #winner-text {
         font-size: 2rem;
+    }
+
+    #debug-info {
+        font-size: 0.7rem;
+        padding: 0.5rem;
+        max-width: 150px;
+    }
+
+    .controls-info {
+        bottom: 80px;
+    }
+
+    .controls-info p {
+        font-size: 0.9rem;
     }
 }

--- a/index.html
+++ b/index.html
@@ -32,6 +32,15 @@
                         <div id="blue-status" class="status">準備中</div>
                     </div>
                 </div>
+
+                <!-- デバッグ情報 -->
+                <div id="debug-info" class="debug-panel"></div>
+
+                <!-- 操作説明 -->
+                <div class="controls-info">
+                    <p>端末を振るか、画面をタップ！</p>
+                </div>
+
                 <button id="reset-button" class="btn btn-small">リセット</button>
             </div>
 


### PR DESCRIPTION
問題点:
- 加速度の変化量を検出していなかった
- 強度が極端に弱かった (0.5)
- デバッグ情報がなく原因特定が困難だった

修正内容:
- 加速度の変化量（デルタ）を計算して適用
- 強度を20倍に増加 (0.5 → 20.0)
- event.accelerationを優先使用（重力を除いた純粋な加速度）
- デバッグパネルを追加して加速度データを可視化
- 画面タップでも振動を発生させる機能を追加
- 物理パラメータを調整（摩擦↓、質量↓、ダンピング↓）
- より大きなトルクとインパルスを適用

これにより、少しの振動でも力士が反応するようになりました。