### PR TITLE
タップ操作によるとんとん相撲に全面刷新

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -170,32 +170,59 @@ p {
     }
 }
 
-/* デバッグパネル */
-#debug-info {
+/* タップエリア */
+.tap-area {
     position: absolute;
-    top: 100px;
+    width: 150px;
+    height: 150px;
+    background: radial-gradient(circle, rgba(102, 126, 234, 0.3) 0%, rgba(102, 126, 234, 0.1) 70%);
+    border: 2px solid rgba(102, 126, 234, 0.5);
+    border-radius: 20px;
+    cursor: pointer;
+    transition: all 0.1s ease;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.tap-area:active,
+.tap-area.active {
+    background: radial-gradient(circle, rgba(102, 126, 234, 0.7) 0%, rgba(102, 126, 234, 0.3) 70%);
+    border-color: rgba(102, 126, 234, 1);
+    transform: scale(0.95);
+}
+
+.tap-top-left {
+    top: 10px;
     left: 10px;
-    background-color: rgba(0, 0, 0, 0.8);
-    padding: 0.8rem;
-    border-radius: 5px;
-    font-size: 0.8rem;
-    font-family: monospace;
-    color: #0f0;
-    border: 1px solid #0f0;
-    max-width: 200px;
-    line-height: 1.4;
+}
+
+.tap-top-right {
+    top: 10px;
+    right: 10px;
+}
+
+.tap-bottom-left {
+    bottom: 70px;
+    left: 10px;
+}
+
+.tap-bottom-right {
+    bottom: 70px;
+    right: 10px;
 }
 
 /* 操作説明 */
 .controls-info {
     position: absolute;
-    bottom: 100px;
+    top: 50%;
     left: 50%;
-    transform: translateX(-50%);
-    background-color: rgba(102, 126, 234, 0.9);
+    transform: translate(-50%, -50%);
+    background-color: rgba(102, 126, 234, 0.8);
     padding: 0.8rem 1.5rem;
     border-radius: 20px;
     text-align: center;
+    pointer-events: none;
 }
 
 .controls-info p {
@@ -233,14 +260,9 @@ p {
         font-size: 2rem;
     }
 
-    #debug-info {
-        font-size: 0.7rem;
-        padding: 0.5rem;
-        max-width: 150px;
-    }
-
-    .controls-info {
-        bottom: 80px;
+    .tap-area {
+        width: 120px;
+        height: 120px;
     }
 
     .controls-info p {

--- a/index.html
+++ b/index.html
@@ -16,9 +16,8 @@
         <div id="ui-overlay">
             <div id="start-screen" class="screen active">
                 <h1>3D とんとん相撲</h1>
-                <p>端末を揺らして力士を動かそう！</p>
+                <p>四隅をタップして土俵を揺らそう！</p>
                 <button id="start-button" class="btn">スタート</button>
-                <p class="info">※加速度センサーの許可が必要です</p>
             </div>
 
             <div id="game-screen" class="screen">
@@ -33,12 +32,15 @@
                     </div>
                 </div>
 
-                <!-- デバッグ情報 -->
-                <div id="debug-info" class="debug-panel"></div>
+                <!-- 四隅のタップエリア -->
+                <div id="tap-top-left" class="tap-area tap-top-left"></div>
+                <div id="tap-top-right" class="tap-area tap-top-right"></div>
+                <div id="tap-bottom-left" class="tap-area tap-bottom-left"></div>
+                <div id="tap-bottom-right" class="tap-area tap-bottom-right"></div>
 
                 <!-- 操作説明 -->
                 <div class="controls-info">
-                    <p>端末を振るか、画面をタップ！</p>
+                    <p>四隅をタップして振動！</p>
                 </div>
 
                 <button id="reset-button" class="btn btn-small">リセット</button>


### PR DESCRIPTION
変更内容:
- 加速度センサー機能を完全に削除
- 四隅のタップエリアを追加（左上、右上、左下、右下）
- タップした位置に応じて力士に力を加える仕様に変更
- 力士の質量を軽量化（0.5 → 0.15）紙の力士を再現
- デバッグパネルを削除
- UIを刷新し、操作説明を変更

技術的な改善:
- タップエリアに視覚的フィードバックを追加
- タップした方向に応じて力の方向を変更
- ランダム性を追加してリアルな揺れを再現
- モバイル対応のタップエリアサイズ調整

これにより、端末を置いたままタップ操作で楽しめる
純粋なとんとん相撲ゲームになりました。